### PR TITLE
Fixed snippet when wrapping Invoke context with EnvContext.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ configurations::
 
     @task()
     def echo(ctx, message):
-        ctx = EnvContext(ctx)
+        ctx = EnvContext(ctx.config)
         run('echo {}'.format(message))
 
 This will fetch the environment specific settings if they are


### PR DESCRIPTION
When creating the EnvContext you need to pass in the config attribute not the entire context object otherwise getting items fails because the path is EnvContext.config.config.<item> when it should be
EnvContext.config.<item>.

Added newline to end of file.